### PR TITLE
refactor: modularize calibration helpers

### DIFF
--- a/app/calib_8_img.py
+++ b/app/calib_8_img.py
@@ -1,78 +1,17 @@
 #!/usr/bin/env python3
-"""
-calib_8_img.py — constrained single-image intrinsics from an AprilGrid.
+"""Constrained single-image intrinsic calibration."""
 
-Strategy (pinhole):
-  • Detect all tag corners with aprilgrid.Detector("t36h11")
-  • Build object points on a Z=0 plane (ROWS×COLS, TAG_MM, GAP_MM)
-  • Solve cv2.calibrateCamera with strong constraints:
-        - FIX_PRINCIPAL_POINT at image center
-        - FIX_SKEW, FIX_ASPECT_RATIO (square pixels)
-        - ZERO_TANGENT_DIST
-        - estimate f, k1, k2 (k3..k6 fixed)
-  • (Optional) visualize undistortion
+import argparse
+import json
+import sys
 
-This is a minimal calibration; multi-view is still superior.
-
-Usage:
-  python calib_8_img.py --image img.jpg --save-k K.json
-"""
-
-import argparse, json, sys
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
-import numpy as np
 import cv2
-from aprilgrid import Detector
+import numpy as np
 
-# ---- Board definition (edit to match your print) ----
-ROWS, COLS = 6, 5
-TAG_CM, GAP_CM = 3.0, 0.6
-TAG_MM = TAG_CM*10.0
-GAP_MM = GAP_CM*10.0
-PITCH_MM = TAG_MM + GAP_MM
-DICT = "t36h11"
+from dexsdk.calib import estimate_intrinsics, detect, save_json
 
-def to_json_safe(x):
-    if isinstance(x, (np.floating, np.float32, np.float64)): return float(x)
-    if isinstance(x, (np.integer,  np.int32,   np.int64)):   return int(x)
-    if isinstance(x, np.ndarray): return x.tolist()
-    return x
 
-def id_to_rc(tag_id: int)->Tuple[int,int]:
-    return tag_id // COLS, tag_id % COLS
-
-def tag_corners_object_mm(tag_id: int) -> np.ndarray:
-    r, c = id_to_rc(tag_id)
-    cx = c * PITCH_MM
-    cy = r * PITCH_MM
-    h  = TAG_MM * 0.5
-    return np.array([
-        [cx-h, cy-h, 0.0],
-        [cx+h, cy-h, 0.0],
-        [cx+h, cy+h, 0.0],
-        [cx-h, cy+h, 0.0],
-    ], dtype=np.float32).reshape(-1,1,3)
-
-def detect(gray: np.ndarray):
-    dets = Detector(DICT).detect(gray)
-    out = []
-    for d in dets:
-        out.append({"id": int(d.tag_id), "corners_px": np.array(d.corners, dtype=np.float32)})
-    return out
-
-def build_points(dets: List[Dict[str,Any]]):
-    obj, img = [], []
-    for d in dets:
-        tid = d["id"]
-        if 0 <= tid < ROWS*COLS:
-            obj.append(tag_corners_object_mm(tid))
-            img.append(d["corners_px"].astype(np.float32))
-    if not obj: 
-        return None, None
-    return np.vstack(obj), np.vstack(img)
-
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--image", required=True)
     ap.add_argument("--save-k", default="", help="Path to save K/dist JSON (recommended).")
@@ -80,71 +19,35 @@ def main():
     args = ap.parse_args()
 
     gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
-    if gray is None: sys.exit(f"[ERROR] Could not read {args.image}")
-    h, w = gray.shape[:2]
+    if gray is None:
+        sys.exit(f"[ERROR] Could not read {args.image}")
 
-    dets = detect(gray)
-    if not dets: sys.exit("[ERROR] No AprilTags detected.")
+    out = estimate_intrinsics(gray)
 
-    obj, img = build_points(dets)
-    if obj is None: sys.exit("[ERROR] No in-grid tag IDs detected.")
-
-    # ---- Constrained single-image calibration ----
-    # Intrinsic guess
-    f0 = 1.2*max(w, h)  # rough, stable starting point
-    K0 = np.array([[f0, 0, w/2.0],
-                   [0,  f0, h/2.0],
-                   [0,   0,   1.0]], dtype=np.float64)
-    dist0 = np.zeros((8,1), dtype=np.float64)
-
-    flags = (
-        cv2.CALIB_USE_INTRINSIC_GUESS    |
-        cv2.CALIB_FIX_PRINCIPAL_POINT    |  # keep at image center
-        cv2.CALIB_FIX_SKEW               |
-        cv2.CALIB_ZERO_TANGENT_DIST      |
-        cv2.CALIB_FIX_K3 | cv2.CALIB_FIX_K4 | cv2.CALIB_FIX_K5 | cv2.CALIB_FIX_K6 |
-        cv2.CALIB_FIX_ASPECT_RATIO          # fx/fy ratio from K0 (1.0)
-    )
-
-    # Calibrate from ONE view (many points)
-    ret, K, dist, rvecs, tvecs = cv2.calibrateCamera(
-        [obj], [img], (w,h), K0, dist0, flags=flags,
-        criteria=(cv2.TERM_CRITERIA_EPS+cv2.TERM_CRITERIA_MAX_ITER, 200, 1e-9)
-    )
-
-    # Simple sanity checks
-    fx, fy, cx, cy = K[0,0], K[1,1], K[0,2], K[1,2]
-    if not (0.2*max(w,h) < fx < 10*max(w,h)): print("[WARN] fx seems off:", fx)
-    if not (0.2*max(w,h) < fy < 10*max(w,h)): print("[WARN] fy seems off:", fy)
-    if abs(cx - w/2.0) > 3 or abs(cy - h/2.0) > 3:
-        print("[WARN] principal point drifted; constraints may not have been applied as expected.")
-
-    # Reproject RMSE
-    proj, _ = cv2.projectPoints(obj, rvecs[0], tvecs[0], K, dist)
-    rmse = float(cv2.norm(img, proj, cv2.NORM_L2) / max(len(obj),1))**0.5
-
-    out = {"model":"pinhole","K":K.tolist(),"dist":dist.tolist(),
-           "image_size":{"w":w,"h":h},"rms_reprojection_error_px":float(ret),
-           "rmse_px": rmse}
     print("\n=== SINGLE-VIEW INTRINSICS ===")
     print(json.dumps(out, indent=2))
 
     if args.save_k:
-        Path(args.save_k).write_text(json.dumps(out, indent=2))
+        save_json(args.save_k, out)
         print(f"[OK] Saved to {args.save_k}")
 
     if args.show:
-        newK, _ = cv2.getOptimalNewCameraMatrix(K, dist, (w,h), alpha=0.0)
+        K = np.array(out["K"], dtype=np.float64)
+        dist = np.array(out["dist"], dtype=np.float64)
+        h, w = out["image_size"]["h"], out["image_size"]["w"]
+        newK, _ = cv2.getOptimalNewCameraMatrix(K, dist, (w, h), alpha=0.0)
         und = cv2.undistort(gray, K, dist, None, newK)
-        # draw detections on undistorted for a quick look
         det2 = detect(und)
         vis = cv2.cvtColor(und, cv2.COLOR_GRAY2BGR)
         for d in det2:
-            c = d["corners_px"].astype(np.int32).reshape(-1,2)
-            cv2.polylines(vis, [c], True, (0,255,0), 2, cv2.LINE_AA)
+            c = d["corners_px"].astype(int).reshape(-1, 2)
+            cv2.polylines(vis, [c], True, (0, 255, 0), 2, cv2.LINE_AA)
         cv2.imshow("Undistorted (single-view intrinsics)", vis)
         print("[INFO] press any key to close")
-        cv2.waitKey(0); cv2.destroyAllWindows()
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+
 
 if __name__ == "__main__":
     main()
+

--- a/app/calib_one_img.py
+++ b/app/calib_one_img.py
@@ -1,82 +1,16 @@
 #!/usr/bin/env python3
+"""Estimate plane scale from a single AprilGrid image."""
 
-"""
-Outputs:
-  • plane_scale (px/mm & mm/px, per axis, robustly fused from tag edges + neighbor pitch)
-  • per-tag edge mm stats, center pitch stats, edge-to-edge gap stats
-  • shows a debug window with tag overlays (no files saved)
+import argparse
+import json
+import sys
 
-Usage:
-  # raw (no undistortion):
-  python calib_one_img.py --image img.jpg
-
-  # use intrinsics:
-  python calib_one_img.py --image img.jpg --k-json K.json
-
-  # faster detection:
-  python calib_one_img.py --image img.jpg --target-width 1200
-"""
-
-import argparse, json, sys, statistics as st
-from typing import Any, Dict, List, Tuple
-import numpy as np
 import cv2
-from pathlib import Path
-from aprilgrid import Detector
 
-# ---- Board definition ----
-ROWS, COLS = 6, 5
-TAG_CM, GAP_CM = 3.0, 0.6
-TAG_MM = TAG_CM*10.0
-GAP_MM = GAP_CM*10.0
-PITCH_MM = TAG_MM + GAP_MM
-DICT = "t36h11"
+from dexsdk.calib import compute_plane_scale
 
-# Bias-correct final scale so median tag edge == TAG_MM
-BIAS_ENFORCE = True
-BIAS_BLEND   = 1.0   # 1=force exact, 0.5=halfway, 0=off
 
-def to_json_safe(x):
-    if isinstance(x, (np.floating, np.float32, np.float64)): return float(x)
-    if isinstance(x, (np.integer,  np.int32,   np.int64)):   return int(x)
-    if isinstance(x, np.ndarray): return x.tolist()
-    return x
-
-def resize_to_width(img: np.ndarray, width: int):
-    if not width or width <= 0: return img, 1.0
-    h, w = img.shape[:2]; s = float(width)/w
-    return cv2.resize(img, (width, int(round(h*s))), interpolation=cv2.INTER_AREA), s
-
-def detect(gray: np.ndarray, target_width: int = 0):
-    work, s = (gray, 1.0) if not target_width or target_width<=0 else resize_to_width(gray, target_width)
-    dets = Detector(DICT).detect(work)
-    out = []
-    for d in dets:
-        out.append({"id": int(d.tag_id),
-                    "corners_px": (np.array(d.corners, dtype=np.float32)/s).astype(np.float32)})
-    return out
-
-def id_to_rc(tag_id: int)->Tuple[int,int]:
-    return tag_id // COLS, tag_id % COLS
-
-def edge_sizes_px(corners_4x1x2: np.ndarray)->Tuple[float,float]:
-    p = corners_4x1x2.reshape(-1,2)
-    tl,tr,br,bl = p[0],p[1],p[2],p[3]
-    w = 0.5*(np.linalg.norm(tr-tl)+np.linalg.norm(br-bl))
-    h = 0.5*(np.linalg.norm(bl-tl)+np.linalg.norm(br-tr))
-    return float(w), float(h)
-
-def robust_median_trim(vals: List[float])->float:
-    arr = np.asarray(vals, dtype=float)
-    if arr.size==0: return float("nan")
-    med = float(np.median(arr))
-    if arr.size<5: return med
-    mad = float(np.median(np.abs(arr-med)))
-    if mad==0: return med
-    keep = arr[np.abs(arr-med) <= 3.0*1.4826*mad]
-    return float(np.median(keep)) if keep.size else med
-
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--image", required=True)
     ap.add_argument("--k-json", default="", help="Intrinsics JSON from single_view_intrinsics.py")
@@ -86,153 +20,48 @@ def main():
     args = ap.parse_args()
 
     gray = cv2.imread(args.image, cv2.IMREAD_GRAYSCALE)
-    if gray is None: sys.exit(f"[ERROR] Could not read {args.image}")
-    h, w = gray.shape[:2]
+    if gray is None:
+        sys.exit(f"[ERROR] Could not read {args.image}")
 
-    # Optional undistort
-    if args.k_json:
-        data = json.loads(Path(args.k_json).read_text())
-        model = data.get("model","pinhole")
-        K = np.array(data["K"], dtype=np.float64)
-        dist = np.array(data["dist"], dtype=np.float64)
-        if model == "fisheye":
-            mapx, mapy = cv2.fisheye.initUndistortRectifyMap(K, dist, np.eye(3), K, (w,h), cv2.CV_32FC1)
-            gray = cv2.remap(gray, mapx, mapy, interpolation=cv2.INTER_LINEAR)
-        else:
-            newK, _ = cv2.getOptimalNewCameraMatrix(K, dist, (w,h), alpha=0.0)
-            gray = cv2.undistort(gray, K, dist, None, newK)
-
-    # Detect
-    dets = detect(gray, args.target_width)
-    if not dets: sys.exit("[ERROR] No AprilTags detected.")
-
-    # Build centers/widths
-    centers, widths = {}, {}
-    ids = sorted(int(d["id"]) for d in dets)
-    for d in dets:
-        tid = int(d["id"])
-        c = d["corners_px"].astype(np.float32)
-        w_px, h_px = edge_sizes_px(c)
-        centers[tid] = (float(c.reshape(-1,2)[:,0].mean()),
-                        float(c.reshape(-1,2)[:,1].mean()))
-        widths[tid]  = (w_px, h_px)
-
-    # Edge-based px/cm
-    edge_x = [widths[i][0]/(TAG_MM/10.0) for i in ids]
-    edge_y = [widths[i][1]/(TAG_MM/10.0) for i in ids]
-
-    # Neighbor px/cm from center pitch
-    start_id = min(ids); dset = set(ids)
-    nbr_x, nbr_y = [], []
-    for r in range(ROWS):
-        for c in range(COLS-1):
-            i1 = start_id+r*COLS+c; i2=i1+1
-            if i1 in dset and i2 in dset:
-                dx = abs(centers[i2][0]-centers[i1][0])
-                nbr_x.append(dx/(PITCH_MM/10.0))
-    for r in range(ROWS-1):
-        for c in range(COLS):
-            i1 = start_id+r*COLS+c; i2=i1+COLS
-            if i1 in dset and i2 in dset:
-                dy = abs(centers[i2][1]-centers[i1][1])
-                nbr_y.append(dy/(PITCH_MM/10.0))
-
-    ex = robust_median_trim(edge_x); ey = robust_median_trim(edge_y)
-    nx = robust_median_trim(nbr_x) if nbr_x else np.nan
-    ny = robust_median_trim(nbr_y) if nbr_y else np.nan
-
-    w_pair = np.clip(args.pair_weight, 0.0, 1.0)
-    px_per_cm_x = (1-w_pair)*ex + w_pair*(nx if not np.isnan(nx) else ex)
-    px_per_cm_y = (1-w_pair)*ey + w_pair*(ny if not np.isnan(ny) else ey)
-
-    px_per_mm_x, px_per_mm_y = px_per_cm_x/10.0, px_per_cm_y/10.0
-
-    # Optional bias: make median tag edge exactly TAG_MM
-    if (not args.no_bias) and BIAS_ENFORCE and BIAS_BLEND>0:
-        w_mm = [widths[i][0]/px_per_mm_x for i in ids]
-        h_mm = [widths[i][1]/px_per_mm_y for i in ids]
-        med_w, med_h = float(np.median(w_mm)), float(np.median(h_mm))
-        kx = (TAG_MM/med_w) if med_w>1e-9 else 1.0
-        ky = (TAG_MM/med_h) if med_h>1e-9 else 1.0
-        px_per_mm_x *= (kx ** BIAS_BLEND)
-        px_per_mm_y *= (ky ** BIAS_BLEND)
-
-    # Per-tag edges & gaps
-    tag_w_mm = [widths[i][0]/px_per_mm_x for i in ids]
-    tag_h_mm = [widths[i][1]/px_per_mm_y for i in ids]
-
-    horiz_center_mm, vert_center_mm = [], []
-    horiz_gap_mm, vert_gap_mm = [], []
-    print("\n[HORIZONTAL PAIRS] (center pitch mm / error; edge-to-edge gap mm / error)")
-    for r in range(ROWS):
-        for c in range(COLS-1):
-            i1 = start_id+r*COLS+c; i2=i1+1
-            if i1 in dset and i2 in dset:
-                dx_mm = abs(centers[i2][0]-centers[i1][0])/px_per_mm_x
-                w1 = widths[i1][0]/px_per_mm_x; w2 = widths[i2][0]/px_per_mm_x
-                gap = dx_mm - 0.5*w1 - 0.5*w2
-                horiz_center_mm.append(dx_mm); horiz_gap_mm.append(gap)
-                print(f"  ids({i1:2d},{i2:2d})  pitch={dx_mm:7.3f}  Δpitch={dx_mm-PITCH_MM:+7.3f}   gap={gap:7.3f}  Δgap={gap-GAP_MM:+7.3f}")
-
-    print("\n[VERTICAL PAIRS]   (center pitch mm / error; edge-to-edge gap mm / error)")
-    for r in range(ROWS-1):
-        for c in range(COLS):
-            i1 = start_id+r*COLS+c; i2=i1+COLS
-            if i1 in dset and i2 in dset:
-                dy_mm = abs(centers[i2][1]-centers[i1][1])/px_per_mm_y
-                h1 = widths[i1][1]/px_per_mm_y; h2 = widths[i2][1]/px_per_mm_y
-                gap = dy_mm - 0.5*h1 - 0.5*h2
-                vert_center_mm.append(dy_mm); vert_gap_mm.append(gap)
-                print(f"  ids({i1:2d},{i2:2d})  pitch={dy_mm:7.3f}  Δpitch={dy_mm-PITCH_MM:+7.3f}   gap={gap:7.3f}  Δgap={gap-GAP_MM:+7.3f}")
-
-    summary = {
-        "plane_scale": {
-            "px_per_mm_x": float(px_per_mm_x),
-            "px_per_mm_y": float(px_per_mm_y),
-            "mm_per_px_x": float(1.0/px_per_mm_x),
-            "mm_per_px_y": float(1.0/px_per_mm_y),
+    res = compute_plane_scale(
+        gray,
+        args.k_json or None,
+        {
+            "target_width": args.target_width,
+            "pair_weight": args.pair_weight,
+            "no_bias": args.no_bias,
         },
-        "length_summary": {
-            "edge_x_mm_stats": _stats(tag_w_mm),
-            "edge_y_mm_stats": _stats(tag_h_mm),
-            "expected_tag_mm": TAG_MM
-        },
-        "gap_summary": {
-            "horiz_center_pitch_stats": _stats(horiz_center_mm),
-            "vert_center_pitch_stats":  _stats(vert_center_mm),
-            "horiz_edge_to_edge_gap_stats": _stats(horiz_gap_mm),
-            "vert_edge_to_edge_gap_stats":  _stats(vert_gap_mm),
-            "expected": {"gap_mm": GAP_MM, "pitch_mm": PITCH_MM}
-        },
-        "detected_ids": ids
-    }
+    )
+
+    summary = res["summary"]
     print("\n=== PX↔MM SUMMARY ===")
     print(json.dumps(summary, indent=2))
 
-    # Visualize
+    gray = res["gray"]
+    px_per_mm_x, px_per_mm_y = res["px_per_mm"]
     vis = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
-    for d in dets:
-        c = d["corners_px"].astype(np.int32).reshape(-1,2)
+    for d in res["detections"]:
+        c = d["corners_px"].astype(int).reshape(-1, 2)
         tid = int(d["id"])
-        cv2.polylines(vis, [c], True, (0,255,0), 2, cv2.LINE_AA)
-        cx, cy = int(c[:,0].mean()), int(c[:,1].mean())
-        cv2.putText(vis, f"{tid}", (cx+6, cy-6),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0,220,0), 2, cv2.LINE_AA)
-    cv2.putText(vis, f"px/mm X={px_per_mm_x:.4f}  Y={px_per_mm_y:.4f}", (12,28),
-                cv2.FONT_HERSHEY_SIMPLEX, 0.7, (40,220,40), 2, cv2.LINE_AA)
+        cv2.polylines(vis, [c], True, (0, 255, 0), 2, cv2.LINE_AA)
+        cx, cy = int(c[:, 0].mean()), int(c[:, 1].mean())
+        cv2.putText(vis, f"{tid}", (cx + 6, cy - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 220, 0), 2, cv2.LINE_AA)
+    cv2.putText(
+        vis,
+        f"px/mm X={px_per_mm_x:.4f}  Y={px_per_mm_y:.4f}",
+        (12, 28),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.7,
+        (40, 220, 40),
+        2,
+        cv2.LINE_AA,
+    )
     cv2.imshow("Detections (undistorted if K given)", vis)
     print("[INFO] press any key to close")
-    cv2.waitKey(0); cv2.destroyAllWindows()
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
 
-def _stats(v):
-    if not v: return {"count":0}
-    a = np.asarray(v, dtype=float)
-    return {
-        "count": int(a.size), "min": float(a.min()),
-        "q25": float(np.percentile(a,25)), "median": float(np.median(a)),
-        "q75": float(np.percentile(a,75)), "max": float(a.max()),
-        "mean": float(a.mean()), "std": float(a.std(ddof=1)) if a.size>1 else 0.0
-    }
 
 if __name__ == "__main__":
     main()
+

--- a/dexsdk/calib/__init__.py
+++ b/dexsdk/calib/__init__.py
@@ -1,0 +1,19 @@
+"""Calibration helpers for DexSDK.
+
+This subpackage exposes utilities for plane-scale estimation from a single
+image as well as a constrained intrinsic calibration.  Convenience JSON
+helpers are also re-exported for simple caching.
+"""
+
+from .plane_scale import compute_plane_scale
+from .single_view_intrinsics import estimate_intrinsics, detect
+from .store import save_json, load_json
+
+__all__ = [
+    "compute_plane_scale",
+    "estimate_intrinsics",
+    "detect",
+    "save_json",
+    "load_json",
+]
+

--- a/dexsdk/calib/plane_scale.py
+++ b/dexsdk/calib/plane_scale.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+"""Plane scale estimation utilities."""
+
+import numpy as np
+import cv2
+from typing import Any, Dict, List, Tuple
+from aprilgrid import Detector
+
+from .store import load_json
+
+# ---- Board definition ----
+ROWS, COLS = 6, 5
+TAG_CM, GAP_CM = 3.0, 0.6
+TAG_MM = TAG_CM * 10.0
+GAP_MM = GAP_CM * 10.0
+PITCH_MM = TAG_MM + GAP_MM
+DICT = "t36h11"
+
+# Bias-correct final scale so median tag edge == TAG_MM
+BIAS_ENFORCE = True
+BIAS_BLEND = 1.0  # 1=force exact, 0.5=halfway, 0=off
+
+
+def resize_to_width(img: np.ndarray, width: int):
+    if not width or width <= 0:
+        return img, 1.0
+    h, w = img.shape[:2]
+    s = float(width) / w
+    return cv2.resize(img, (width, int(round(h * s))), interpolation=cv2.INTER_AREA), s
+
+
+def detect(gray: np.ndarray, target_width: int = 0):
+    work, s = (gray, 1.0) if not target_width or target_width <= 0 else resize_to_width(gray, target_width)
+    dets = Detector(DICT).detect(work)
+    out = []
+    for d in dets:
+        out.append({
+            "id": int(d.tag_id),
+            "corners_px": (np.array(d.corners, dtype=np.float32) / s).astype(np.float32),
+        })
+    return out
+
+
+def edge_sizes_px(corners_4x1x2: np.ndarray) -> Tuple[float, float]:
+    p = corners_4x1x2.reshape(-1, 2)
+    tl, tr, br, bl = p[0], p[1], p[2], p[3]
+    w = 0.5 * (np.linalg.norm(tr - tl) + np.linalg.norm(br - bl))
+    h = 0.5 * (np.linalg.norm(bl - tl) + np.linalg.norm(br - tr))
+    return float(w), float(h)
+
+
+def robust_median_trim(vals: List[float]) -> float:
+    arr = np.asarray(vals, dtype=float)
+    if arr.size == 0:
+        return float("nan")
+    med = float(np.median(arr))
+    if arr.size < 5:
+        return med
+    mad = float(np.median(np.abs(arr - med)))
+    if mad == 0:
+        return med
+    keep = arr[np.abs(arr - med) <= 3.0 * 1.4826 * mad]
+    return float(np.median(keep)) if keep.size else med
+
+
+def _stats(v: List[float]) -> Dict[str, Any]:
+    if not v:
+        return {"count": 0}
+    a = np.asarray(v, dtype=float)
+    return {
+        "count": int(a.size),
+        "min": float(a.min()),
+        "q25": float(np.percentile(a, 25)),
+        "median": float(np.median(a)),
+        "q75": float(np.percentile(a, 75)),
+        "max": float(a.max()),
+        "mean": float(a.mean()),
+        "std": float(a.std(ddof=1)) if a.size > 1 else 0.0,
+    }
+
+
+def compute_plane_scale(gray: np.ndarray, K_json: str | None, cfg: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Estimate plane scale from a single AprilGrid image.
+
+    Parameters
+    ----------
+    gray : np.ndarray
+        Input grayscale image.
+    K_json : str | None
+        Optional path to intrinsics JSON for undistortion.
+    cfg : Dict[str, Any] | None
+        Optional configuration dict with keys:
+        ``target_width`` (int), ``pair_weight`` (float), ``no_bias`` (bool).
+
+    Returns
+    -------
+    Dict[str, Any]
+        Contains ``summary`` (public JSON), ``detections`` (list), ``gray`` and
+        ``px_per_mm`` tuple for visualization.
+    """
+
+    if cfg is None:
+        cfg = {}
+    target_width = int(cfg.get("target_width", 0))
+    pair_weight = float(cfg.get("pair_weight", 0.5))
+    no_bias = bool(cfg.get("no_bias", False))
+
+    h, w = gray.shape[:2]
+
+    # Optional undistort
+    if K_json:
+        data = load_json(K_json)
+        if data is None:
+            raise FileNotFoundError(K_json)
+        model = data.get("model", "pinhole")
+        K = np.array(data["K"], dtype=np.float64)
+        dist = np.array(data["dist"], dtype=np.float64)
+        if model == "fisheye":
+            mapx, mapy = cv2.fisheye.initUndistortRectifyMap(
+                K, dist, np.eye(3), K, (w, h), cv2.CV_32FC1
+            )
+            gray = cv2.remap(gray, mapx, mapy, interpolation=cv2.INTER_LINEAR)
+        else:
+            newK, _ = cv2.getOptimalNewCameraMatrix(K, dist, (w, h), alpha=0.0)
+            gray = cv2.undistort(gray, K, dist, None, newK)
+
+    dets = detect(gray, target_width)
+    if not dets:
+        raise RuntimeError("No AprilTags detected.")
+
+    # Build centers/widths
+    centers, widths = {}, {}
+    ids = sorted(int(d["id"]) for d in dets)
+    for d in dets:
+        tid = int(d["id"])
+        c = d["corners_px"].astype(np.float32)
+        w_px, h_px = edge_sizes_px(c)
+        centers[tid] = (
+            float(c.reshape(-1, 2)[:, 0].mean()),
+            float(c.reshape(-1, 2)[:, 1].mean()),
+        )
+        widths[tid] = (w_px, h_px)
+
+    # Edge-based px/cm
+    edge_x = [widths[i][0] / (TAG_MM / 10.0) for i in ids]
+    edge_y = [widths[i][1] / (TAG_MM / 10.0) for i in ids]
+
+    # Neighbor px/cm from center pitch
+    start_id = min(ids)
+    dset = set(ids)
+    nbr_x, nbr_y = [], []
+    for r in range(ROWS):
+        for c in range(COLS - 1):
+            i1 = start_id + r * COLS + c
+            i2 = i1 + 1
+            if i1 in dset and i2 in dset:
+                dx = abs(centers[i2][0] - centers[i1][0])
+                nbr_x.append(dx / (PITCH_MM / 10.0))
+    for r in range(ROWS - 1):
+        for c in range(COLS):
+            i1 = start_id + r * COLS + c
+            i2 = i1 + COLS
+            if i1 in dset and i2 in dset:
+                dy = abs(centers[i2][1] - centers[i1][1])
+                nbr_y.append(dy / (PITCH_MM / 10.0))
+
+    ex = robust_median_trim(edge_x)
+    ey = robust_median_trim(edge_y)
+    nx = robust_median_trim(nbr_x) if nbr_x else np.nan
+    ny = robust_median_trim(nbr_y) if nbr_y else np.nan
+
+    w_pair = np.clip(pair_weight, 0.0, 1.0)
+    px_per_cm_x = (1 - w_pair) * ex + w_pair * (nx if not np.isnan(nx) else ex)
+    px_per_cm_y = (1 - w_pair) * ey + w_pair * (ny if not np.isnan(ny) else ey)
+
+    px_per_mm_x, px_per_mm_y = px_per_cm_x / 10.0, px_per_cm_y / 10.0
+
+    # Optional bias: make median tag edge exactly TAG_MM
+    if (not no_bias) and BIAS_ENFORCE and BIAS_BLEND > 0:
+        w_mm = [widths[i][0] / px_per_mm_x for i in ids]
+        h_mm = [widths[i][1] / px_per_mm_y for i in ids]
+        med_w, med_h = float(np.median(w_mm)), float(np.median(h_mm))
+        kx = (TAG_MM / med_w) if med_w > 1e-9 else 1.0
+        ky = (TAG_MM / med_h) if med_h > 1e-9 else 1.0
+        px_per_mm_x *= kx ** BIAS_BLEND
+        px_per_mm_y *= ky ** BIAS_BLEND
+
+    # Per-tag edges & gaps
+    tag_w_mm = [widths[i][0] / px_per_mm_x for i in ids]
+    tag_h_mm = [widths[i][1] / px_per_mm_y for i in ids]
+
+    horiz_center_mm, vert_center_mm = [], []
+    horiz_gap_mm, vert_gap_mm = [], []
+    for r in range(ROWS):
+        for c in range(COLS - 1):
+            i1 = start_id + r * COLS + c
+            i2 = i1 + 1
+            if i1 in dset and i2 in dset:
+                dx_mm = abs(centers[i2][0] - centers[i1][0]) / px_per_mm_x
+                w1 = widths[i1][0] / px_per_mm_x
+                w2 = widths[i2][0] / px_per_mm_x
+                gap = dx_mm - 0.5 * w1 - 0.5 * w2
+                horiz_center_mm.append(dx_mm)
+                horiz_gap_mm.append(gap)
+    for r in range(ROWS - 1):
+        for c in range(COLS):
+            i1 = start_id + r * COLS + c
+            i2 = i1 + COLS
+            if i1 in dset and i2 in dset:
+                dy_mm = abs(centers[i2][1] - centers[i1][1]) / px_per_mm_y
+                h1 = widths[i1][1] / px_per_mm_y
+                h2 = widths[i2][1] / px_per_mm_y
+                gap = dy_mm - 0.5 * h1 - 0.5 * h2
+                vert_center_mm.append(dy_mm)
+                vert_gap_mm.append(gap)
+
+    summary = {
+        "plane_scale": {
+            "px_per_mm_x": float(px_per_mm_x),
+            "px_per_mm_y": float(px_per_mm_y),
+            "mm_per_px_x": float(1.0 / px_per_mm_x),
+            "mm_per_px_y": float(1.0 / px_per_mm_y),
+        },
+        "length_summary": {
+            "edge_x_mm_stats": _stats(tag_w_mm),
+            "edge_y_mm_stats": _stats(tag_h_mm),
+            "expected_tag_mm": TAG_MM,
+        },
+        "gap_summary": {
+            "horiz_center_pitch_stats": _stats(horiz_center_mm),
+            "vert_center_pitch_stats": _stats(vert_center_mm),
+            "horiz_edge_to_edge_gap_stats": _stats(horiz_gap_mm),
+            "vert_edge_to_edge_gap_stats": _stats(vert_gap_mm),
+            "expected": {"gap_mm": GAP_MM, "pitch_mm": PITCH_MM},
+        },
+        "detected_ids": ids,
+    }
+
+    return {
+        "summary": summary,
+        "detections": dets,
+        "gray": gray,
+        "px_per_mm": (px_per_mm_x, px_per_mm_y),
+    }
+

--- a/dexsdk/calib/single_view_intrinsics.py
+++ b/dexsdk/calib/single_view_intrinsics.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Single-view intrinsic calibration utilities."""
+
+import numpy as np
+import cv2
+from typing import Any, Dict, List, Tuple
+from aprilgrid import Detector
+
+# ---- Board definition (edit to match your print) ----
+ROWS, COLS = 6, 5
+TAG_CM, GAP_CM = 3.0, 0.6
+TAG_MM = TAG_CM * 10.0
+GAP_MM = GAP_CM * 10.0
+PITCH_MM = TAG_MM + GAP_MM
+DICT = "t36h11"
+
+
+def id_to_rc(tag_id: int) -> Tuple[int, int]:
+    return tag_id // COLS, tag_id % COLS
+
+
+def tag_corners_object_mm(tag_id: int) -> np.ndarray:
+    r, c = id_to_rc(tag_id)
+    cx = c * PITCH_MM
+    cy = r * PITCH_MM
+    h = TAG_MM * 0.5
+    return np.array(
+        [
+            [cx - h, cy - h, 0.0],
+            [cx + h, cy - h, 0.0],
+            [cx + h, cy + h, 0.0],
+            [cx - h, cy + h, 0.0],
+        ],
+        dtype=np.float32,
+    ).reshape(-1, 1, 3)
+
+
+def detect(gray: np.ndarray):
+    dets = Detector(DICT).detect(gray)
+    out = []
+    for d in dets:
+        out.append({"id": int(d.tag_id), "corners_px": np.array(d.corners, dtype=np.float32)})
+    return out
+
+
+def build_points(dets: List[Dict[str, Any]]):
+    obj, img = [], []
+    for d in dets:
+        tid = d["id"]
+        if 0 <= tid < ROWS * COLS:
+            obj.append(tag_corners_object_mm(tid))
+            img.append(d["corners_px"].astype(np.float32))
+    if not obj:
+        return None, None
+    return np.vstack(obj), np.vstack(img)
+
+
+def estimate_intrinsics(gray: np.ndarray) -> Dict[str, Any]:
+    """Estimate camera intrinsics from a single AprilGrid view."""
+
+    h, w = gray.shape[:2]
+
+    dets = detect(gray)
+    if not dets:
+        raise RuntimeError("No AprilTags detected.")
+
+    obj, img = build_points(dets)
+    if obj is None:
+        raise RuntimeError("No in-grid tag IDs detected.")
+
+    # ---- Constrained single-image calibration ----
+    f0 = 1.2 * max(w, h)
+    K0 = np.array([[f0, 0, w / 2.0], [0, f0, h / 2.0], [0, 0, 1.0]], dtype=np.float64)
+    dist0 = np.zeros((8, 1), dtype=np.float64)
+
+    flags = (
+        cv2.CALIB_USE_INTRINSIC_GUESS
+        | cv2.CALIB_FIX_PRINCIPAL_POINT
+        | cv2.CALIB_FIX_SKEW
+        | cv2.CALIB_ZERO_TANGENT_DIST
+        | cv2.CALIB_FIX_K3
+        | cv2.CALIB_FIX_K4
+        | cv2.CALIB_FIX_K5
+        | cv2.CALIB_FIX_K6
+        | cv2.CALIB_FIX_ASPECT_RATIO
+    )
+
+    ret, K, dist, rvecs, tvecs = cv2.calibrateCamera(
+        [obj],
+        [img],
+        (w, h),
+        K0,
+        dist0,
+        flags=flags,
+        criteria=(cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 200, 1e-9),
+    )
+
+    fx, fy, cx, cy = K[0, 0], K[1, 1], K[0, 2], K[1, 2]
+    if not (0.2 * max(w, h) < fx < 10 * max(w, h)):
+        print("[WARN] fx seems off:", fx)
+    if not (0.2 * max(w, h) < fy < 10 * max(w, h)):
+        print("[WARN] fy seems off:", fy)
+    if abs(cx - w / 2.0) > 3 or abs(cy - h / 2.0) > 3:
+        print("[WARN] principal point drifted; constraints may not have been applied as expected.")
+
+    proj, _ = cv2.projectPoints(obj, rvecs[0], tvecs[0], K, dist)
+    rmse = float(cv2.norm(img, proj, cv2.NORM_L2) / max(len(obj), 1)) ** 0.5
+
+    return {
+        "model": "pinhole",
+        "K": K.tolist(),
+        "dist": dist.tolist(),
+        "image_size": {"w": w, "h": h},
+        "rms_reprojection_error_px": float(ret),
+        "rmse_px": rmse,
+    }
+

--- a/dexsdk/calib/store.py
+++ b/dexsdk/calib/store.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Simple JSON cache helpers."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+DEFAULT_DIR = Path.home() / ".vim_rb"
+
+
+def _resolve(path: str | Path) -> Path:
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        p = DEFAULT_DIR / p
+    return p
+
+
+def save_json(path: str, data: Any) -> Path:
+    p = _resolve(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return p
+
+
+def load_json(path: str) -> Dict[str, Any] | None:
+    p = _resolve(path)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+


### PR DESCRIPTION
## Summary
- modularize plane-scale and intrinsics calibration under `dexsdk.calib`
- add JSON cache utilities with default `~/.vim_rb`
- slim command-line calibration scripts to wrapper APIs

## Testing
- `python -m pytest`
- `PYTHONPATH=. python app/calib_one_img.py --image app/img.jpg` *(fails: Qt platform plugin "xcb" not loaded)*
- `PYTHONPATH=. python app/calib_8_img.py --image app/img.jpg` *(fails: module 'cv2' has no attribute 'CALIB_FIX_SKEW')*


------
https://chatgpt.com/codex/tasks/task_e_68c7aba44bb483298f36fcbb2722fa3d